### PR TITLE
Fuzzy matching of Primitives using floating-point "fingerprints".

### DIFF
--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -74,4 +74,4 @@ pub use gltfext::*;
 
 /// Mapping glTF objects to unique keys for melding purposes.
 pub mod meld_keys;
-pub use meld_keys::MeldKey;
+pub use meld_keys::{Fingerprint, MeldKey};

--- a/native/src/meld_keys/fingerprints.rs
+++ b/native/src/meld_keys/fingerprints.rs
@@ -1,0 +1,78 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+//
+
+use gltf::{mesh::Primitive, Buffer};
+
+use spectral::prelude::*;
+
+use crate::{Fingerprint, Result};
+
+/// Computes a `Fingerprint` from a `Primitive`.
+///
+/// A fingerprint needs to be independent of triangle order and vertex order, and obviously it
+/// should be non-trivially different from the fingerprint of some other `Primitive`. This isn't
+/// as obvious as it seems: for example, if we simply took the geometric average of positions,
+/// all shapes that are symmetric around origin, regardless of scale, would be identical.
+///
+/// We look at vertex positions and vertex colours, and simply add them up, with an added
+/// skew to the Y and Z dimensions, to break symmetries.
+///
+/// More complexity could be added here, if warranted.
+pub fn build_fingerprint(primitive: &Primitive, blob: &[u8]) -> Result<Fingerprint> {
+    let buf_to_blob = |buf: Buffer| {
+        assert_that(&buf.index()).is_equal_to(0);
+        if blob.is_empty() {
+            None
+        } else {
+            Some(blob)
+        }
+    };
+
+    let reader = primitive.reader(buf_to_blob);
+
+    let positions: Vec<[f32; 3]> = reader
+        .read_positions()
+        .ok_or(format!("Primitive lacks position data!"))?
+        .collect();
+
+    let indices: Vec<u32> = reader
+        .read_indices()
+        .ok_or(format!("Primitive lacks indices!"))?
+        .into_u32()
+        .collect();
+
+    let count = indices.len() as f64;
+    println!("Index count: {}", count);
+
+    let mut cumulative_fingerprint = {
+        let mut print: f64 = 0.0;
+        for &ix in &indices {
+            print += vec3_to_print(positions[ix as usize]) / count;
+        }
+        print
+    };
+
+    if let Some(colors) = reader.read_colors(0) {
+        let colors: Vec<[f32; 4]> = colors.into_rgba_f32().collect();
+
+        cumulative_fingerprint += {
+            let mut print: f64 = 0.0;
+            for &ix in &indices {
+                print += vec4_to_print(colors[ix as usize]) / count;
+            }
+            print
+        }
+    }
+
+    Ok(cumulative_fingerprint)
+}
+
+fn vec3_to_print(vec: [f32; 3]) -> f64 {
+    // arbitrary symmetry-breaking shear
+    (vec[0] + 1.3 * vec[1] + 1.7 * vec[2]) as f64
+}
+
+fn vec4_to_print(vec: [f32; 4]) -> f64 {
+    // arbitrary symmetry-breaking shear
+    (vec[0] + 1.1 * vec[1] + 1.3 * vec[2] + 1.5 * vec[3]) as f64
+}

--- a/native/src/meld_keys/fingerprints.rs
+++ b/native/src/meld_keys/fingerprints.rs
@@ -42,7 +42,6 @@ pub fn build_fingerprint(primitive: &Primitive, blob: &[u8]) -> Result<Fingerpri
         .collect();
 
     let count = indices.len() as f64;
-    println!("Index count: {}", count);
 
     let mut cumulative_fingerprint = {
         let mut print: f64 = 0.0;

--- a/native/src/meld_keys/key_trait.rs
+++ b/native/src/meld_keys/key_trait.rs
@@ -4,8 +4,9 @@
 use sha1::Sha1;
 
 use gltf::json::texture;
+use gltf::json::Mesh;
 use gltf::json::{material::NormalTexture, material::OcclusionTexture};
-use gltf::json::{texture::Sampler, Image, Index, Material, Mesh, Texture};
+use gltf::json::{texture::Sampler, Image, Index, Material, Texture};
 
 use crate::{MeldKey, Result, WorkAsset};
 

--- a/native/src/meld_keys/mod.rs
+++ b/native/src/meld_keys/mod.rs
@@ -4,17 +4,16 @@
 mod key_trait;
 pub use key_trait::HasKeyForVariants;
 
-/// A short string that uniquely identifies certain glTF objects.
-///
-/// Two logically identical objects can be bitwise quite different between different glTF
-/// exports, different versions of the exporter, or even different runs with the same exporter.
-///
-/// For example:
-/// - The order of glTF object arrays is unimportant, and may vary freely between runs.
-/// - Scene graphs can be constructed in countless ways while representing the same structure.
-/// - Neither mesh triangles nor vertices are strictly ordered, so identity is non-trivial.
-/// - Floating-point computation is inexact, so comparisons should be fuzzy, à la `||Δv|| < ε`.
-///
-/// NOTE: In practice, we currently compute these keys in a very straight-forward fashion. The
-/// one for a `Mesh`, for example, is simply its name. This likely won't suffice in the long run.
+mod fingerprints;
+pub use fingerprints::build_fingerprint;
+
+/// A short string that uniquely identifies all glTF objects other than `Mesh` `Primitives`.
 pub type MeldKey = String;
+
+/// A floating-point number that identifies logically identical `Mesh` `Primitives`.
+///
+/// Most glTF objects are given a simple, unique key as part of the `MeldKey` mechanism.
+/// For geometry, things are trickier. To begin with, neither the order of triangles (indices)
+/// nor vectors are important, so any comparison must be order-agnostic. Worse, floating-point
+/// calculations are inexact, and so identity there must be of the ||x - x'|| < ε type.
+pub type Fingerprint = f64;

--- a/native/src/work_asset/construct.rs
+++ b/native/src/work_asset/construct.rs
@@ -79,6 +79,14 @@ impl WorkAsset {
     /// `Texture`, `Material` and `Mesh`. Please consult the `::meld_keys` module for details on
     /// meld keys.
     ///
+    /// We require that `Mesh` keys are unique, and protest if they're not.
+    ///
+    /// Next, every `Primitives` of every `Mesh` is given a `Fingerprint`, which is essentially a
+    /// floating-point `MeldKey` that can be used to match logically identical objects that have
+    /// numerically drifted apart to some microscopic degree.
+    ///
+    /// We require that `Primitive` fingerprints are unique, to within a tolerance.
+    ///
     /// Finally, each mesh and mesh primitive is inspected, and any `FB_material_variants` data is
     /// parsed and converted to a Tag->MeldKey mapping, filling in `mesh_primitive_variants` and
     /// completing the `WorkAsset` construction.

--- a/native/src/work_asset/meld.rs
+++ b/native/src/work_asset/meld.rs
@@ -43,9 +43,6 @@ impl<'a> WorkAsset {
 
                     let mut other_map = other.variant_mapping(other_mesh_ix, primitive_ix).clone();
 
-                    // NOTE[TODO]: We should look primitives up per key, just as we do with all
-                    // other glTF objects, but here suddenly we assume that meshes between two
-                    // assets have precisely the same vectors of primitives in the same order.
                     let base_print = base.mesh_primitive_fingerprints[base_mesh_ix][primitive_ix];
                     let other_primitive_ix = other
                         .find_almost_equal_fingerprint(other_mesh_ix, &base_print, None)

--- a/native/src/work_asset/meld.rs
+++ b/native/src/work_asset/meld.rs
@@ -42,11 +42,18 @@ impl<'a> WorkAsset {
                     }
 
                     let mut other_map = other.variant_mapping(other_mesh_ix, primitive_ix).clone();
+
                     // NOTE[TODO]: We should look primitives up per key, just as we do with all
                     // other glTF objects, but here suddenly we assume that meshes between two
                     // assets have precisely the same vectors of primitives in the same order.
-                    let other_primitive = &other_primitives[primitive_ix];
-                    if let Some(other_material) = other_primitive.material {
+                    let base_print = base.mesh_primitive_fingerprints[base_mesh_ix][primitive_ix];
+                    let other_primitive_ix = other
+                        .find_almost_equal_fingerprint(other_mesh_ix, &base_print, None)
+                        .ok_or(format!(
+                            "Melded asset has no equivalent to base mesh {}, primitive {}.",
+                            base_mesh_ix, primitive_ix
+                        ))?;
+                    if let Some(other_material) = other_primitives[other_primitive_ix].material {
                         if !other_map.contains_key(&other.default_tag) {
                             other_map.insert(
                                 other.default_tag.clone(),

--- a/native/src/work_asset/mod.rs
+++ b/native/src/work_asset/mod.rs
@@ -21,7 +21,7 @@ const EPS_FINGERPRINT: f64 = 1e-6;
 /// The primary internal data structure, which enables and accelerates the melding operation.
 ///
 /// The first half of the asset constitutes all the data needed to export fully variational glTF:
-/// the source document and blob, a default tag, and the per- mesh, per-primitive mapping of tags to
+/// the source document and blob, a default tag, and the per-mesh, per-primitive mapping of tags to
 /// materials.
 ///
 /// The second half are meld keys for various glTF objects, which are used heavily in the melding
@@ -57,7 +57,9 @@ pub struct WorkAsset {
     /// A `MeldKey` for each `Texture`; a straight-forward string expansion of its state.
     texture_keys: Vec<MeldKey>,
 
-    mesh_primitive_fingerprints: Vec<Vec<f64>>,
+    /// Each `Primitive` of each `Mesh` has a `Fingerprint` computed for it, and they are
+    /// stored herein.
+    mesh_primitive_fingerprints: Vec<Vec<Fingerprint>>,
 }
 
 impl WorkAsset {
@@ -120,21 +122,12 @@ impl WorkAsset {
         for (primitive_ix, primitive_print) in prints.iter().enumerate() {
             if let Some(exclude_ix) = exclude_ix {
                 if exclude_ix == primitive_ix {
-                    println!("Excluding test for ix {}.", exclude_ix);
                     continue;
                 }
             }
             if (primitive_print - print).abs() < EPS_FINGERPRINT {
-                println!(
-                    "Successfully tested {} against #{}: {}",
-                    print, primitive_ix, primitive_print
-                );
                 return Some(primitive_ix);
             }
-            println!(
-                "No match testing {} against #{}: {}",
-                print, primitive_ix, primitive_print
-            );
         }
         return None;
     }


### PR DESCRIPTION
The last major known logical hole is that we during the meld operation, we simply assumed that for a given matched pair of meshes, the primitives of that mesh would appear in order, and be identical.

Rather than build precise keys for primitives, we build floating-point fingerprints, and then we match not by precise hashmap style lookup, as with the keys, but comparing each primitive against each primitive in the other asset, and require that they're equal to within some epsilon's tolerance.

There's still some work to be done, and the actual fingerprint logic is probably too simplistic for the long haul, but this lays the foundation and patches the hole.
