### PR TITLE
Rename extension product from FB_variant_materials -> KHR_materials_variants (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ latency.
 
 We're making this internal tool publicly available with the hope of helping the glTF
 ecosystem come together around a common, open format. In this prerelease version, the tool
-produces files with the vendor extension
-[`FB_material_variants`](https://github.com/KhronosGroup/glTF/pull/1681). We are hopeful
+produces files with the Khronos extension
+[`KHR_materials_variants`](https://github.com/KhronosGroup/glTF/pull/1681). We are hopeful
 that the glTF community will find speedy consensus around a ratified extension.
 
-In this prerelease version, the tool produces files with the vendor extension [`FB_material_variants`](https://github.com/KhronosGroup/glTF/blob/f0ab429b4260cfa91925bcf5044624968773902c/extensions/2.0/Vendor/FB_material_variants/README.md). We are hopeful that the glTF community will find speedy consensus around a multi-vendor extension.
+In this prerelease version, the tool produces files with the Khronos extension [`KHR_materials_variants`](https://github.com/KhronosGroup/glTF/blob/07c109becc3153d0d982d6c2086da7da979ab439/extensions/2.0/Khronos//KHR_materials_variants/README.md). We are hopeful that the glTF community will find speedy consensus around a Khronos extension.
 
 Our aspirational roadmap includes the development of a web app which would leverage
 WebAssembly to run entirely in the browser. There will also be a native CLI.

--- a/assets/pinecones/variational/Pinecone.gltf
+++ b/assets/pinecones/variational/Pinecone.gltf
@@ -4,7 +4,7 @@
     "version": "2.0"
   },
   "extensionsUsed": [
-    "FB_material_variants"
+    "KHR_materials_variants"
   ],
   "scene": 0,
   "buffers": [
@@ -128,7 +128,7 @@
           },
           "indices": 0,
           "extensions": {
-            "FB_material_variants": {
+            "KHR_materials_variants": {
               "mapping": [
                 {
                   "tags": [

--- a/assets/tank_teapots/TexturedTankTeapot-export.gltf
+++ b/assets/tank_teapots/TexturedTankTeapot-export.gltf
@@ -14775,7 +14775,7 @@
   ],
   "scene": 0,
   "extras": {
-  "FB_material_variants": {
+  "KHR_materials_variants": {
     "default_tag": "original"
   }
 },

--- a/native/src/extension/mod.rs
+++ b/native/src/extension/mod.rs
@@ -2,7 +2,7 @@
 //
 
 //! Implementation of our
-//! [`FB_variant_mapping`](https://github.com/zellski/glTF/blob/ext/zell-fb-asset-variants/extensions/2.0/Vendor/FB_material_variants/README.md)
+//! [`FB_variant_mapping`](https://github.com/zellski/glTF/blob/ext/zell-fb-asset-variants/extensions/2.0/Khronos/KHR_materials_variants/README.md)
 //! extension.
 //!
 //! We're specifically concerned with reading and writing values that are meaningful from
@@ -11,7 +11,7 @@
 
 use gltf::json::Root;
 
-const FB_MATERIAL_VARIANTS: &str = "FB_material_variants";
+const KHR_MATERIALS_VARIANTS: &str = "KHR_materials_variants";
 
 mod on_root;
 pub use on_root::{get_validated_extension_tag, set_extension_tag};
@@ -23,7 +23,7 @@ pub use on_primitive::{extract_variant_map, write_variant_map};
 ///
 pub fn install(root: &mut Root) {
     let used = &mut root.extensions_used;
-    if !used.contains(&String::from(FB_MATERIAL_VARIANTS)) {
-        used.push(String::from(FB_MATERIAL_VARIANTS));
+    if !used.contains(&String::from(KHR_MATERIALS_VARIANTS)) {
+        used.push(String::from(KHR_MATERIALS_VARIANTS));
     }
 }

--- a/native/src/extension/on_primitive.rs
+++ b/native/src/extension/on_primitive.rs
@@ -7,7 +7,7 @@ use serde_derive::{Deserialize, Serialize};
 
 use gltf::json::mesh::Primitive;
 
-use super::FB_MATERIAL_VARIANTS;
+use super::KHR_MATERIALS_VARIANTS;
 use crate::{Result, Tag};
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -25,17 +25,17 @@ pub struct FBMaterialVariantPrimitiveEntry {
     pub tags: Vec<Tag>,
 }
 
-/// Write the `tag_to_ix` mapping to the `Primitive' in `FB_material_variants` form.
+/// Write the `tag_to_ix` mapping to the `Primitive' in `KHR_materials_variants` form.
 ///
 /// This method guarantees a deterministic ordering of the output.
 ///
-/// Please see [the `FB_material_variants`
-/// spec](https://github.com/zellski/glTF/blob/ext/zell-fb-asset-variants/extensions/2.0/Vendor/FB_material_variants/README.md)
+/// Please see [the `KHR_materials_variants`
+/// spec](https://github.com/zellski/glTF/blob/ext/zell-fb-asset-variants/extensions/2.0/Khronos/KHR_materials_variants/README.md)
 /// for further details.
 pub fn write_variant_map(primitive: &mut Primitive, tag_to_ix: &HashMap<Tag, usize>) -> Result<()> {
     if tag_to_ix.is_empty() {
         if let Some(extensions) = &mut primitive.extensions {
-            extensions.others.remove(FB_MATERIAL_VARIANTS);
+            extensions.others.remove(KHR_MATERIALS_VARIANTS);
         }
         return Ok(());
     }
@@ -80,18 +80,18 @@ pub fn write_variant_map(primitive: &mut Primitive, tag_to_ix: &HashMap<Tag, usi
         .extensions
         .get_or_insert(Default::default())
         .others
-        .insert(FB_MATERIAL_VARIANTS.to_owned(), value);
+        .insert(KHR_MATERIALS_VARIANTS.to_owned(), value);
     Ok(())
 }
 
-/// Parses and returns the `FB_material_variants` data on a primitive, if any.
+/// Parses and returns the `KHR_materials_variants` data on a primitive, if any.
 ///
-/// Please see [the `FB_material_variants`
-/// spec](https://github.com/zellski/glTF/blob/ext/zell-fb-asset-variants/extensions/2.0/Vendor/FB_material_variants/README.md)
+/// Please see [the `KHR_materials_variants`
+/// spec](https://github.com/zellski/glTF/blob/ext/zell-fb-asset-variants/extensions/2.0/Khronos/KHR_materials_variants/README.md)
 /// for further details
 pub fn extract_variant_map(primitive: &Primitive) -> Result<HashMap<Tag, usize>> {
     if let Some(extensions) = &primitive.extensions {
-        if let Some(boxed) = extensions.others.get(FB_MATERIAL_VARIANTS) {
+        if let Some(boxed) = extensions.others.get(KHR_MATERIALS_VARIANTS) {
             let json_string = &boxed.to_string();
             let parse: serde_json::Result<FBMaterialVariantPrimitiveExtension> =
                 serde_json::from_str(json_string);
@@ -106,7 +106,7 @@ pub fn extract_variant_map(primitive: &Primitive) -> Result<HashMap<Tag, usize>>
                     Ok(result)
                 }
                 Err(e) => Err(format!(
-                    "Bad JSON in FB_material_variants extension: {}; json = {}",
+                    "Bad JSON in KHR_materials_variants extension: {}; json = {}",
                     e.to_string(),
                     json_string,
                 )),

--- a/native/src/extension/on_root.rs
+++ b/native/src/extension/on_root.rs
@@ -5,7 +5,7 @@ use serde_derive::{Deserialize, Serialize};
 
 use gltf::json::Root;
 
-use super::FB_MATERIAL_VARIANTS;
+use super::KHR_MATERIALS_VARIANTS;
 use crate::{Result, Tag};
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -13,10 +13,10 @@ pub struct FBMaterialVariantRootExtension {
     pub default_tag: Tag,
 }
 
-/// Write the given `default_tag` into the JSON `Root` in `FB_material_variants` form.
+/// Write the given `default_tag` into the JSON `Root` in `KHR_materials_variants` form.
 ///
-/// Please see [the `FB_material_variants`
-/// spec](https://github.com/zellski/glTF/blob/ext/zell-fb-asset-variants/extensions/2.0/Vendor/FB_material_variants/README.md)
+/// Please see [the `KHR_materials_variants`
+/// spec](https://github.com/zellski/glTF/blob/ext/zell-fb-asset-variants/extensions/2.0/Khronos/KHR_materials_variants/README.md)
 /// for further details.
 pub fn set_extension_tag(root: &mut Root, default_tag: &Tag) -> Result<()> {
     let extension = FBMaterialVariantRootExtension {
@@ -35,14 +35,14 @@ pub fn set_extension_tag(root: &mut Root, default_tag: &Tag) -> Result<()> {
     root.extensions
         .get_or_insert(Default::default())
         .others
-        .insert(FB_MATERIAL_VARIANTS.to_owned(), value);
+        .insert(KHR_MATERIALS_VARIANTS.to_owned(), value);
     Ok(())
 }
 
-/// Parses and returns the default key in any `FB_material_variants` extension on the JSON `Root`.
+/// Parses and returns the default key in any `KHR_materials_variants` extension on the JSON `Root`.
 ///
-/// Please see [the `FB_material_variants`
-/// spec](https://github.com/zellski/glTF/blob/ext/zell-fb-asset-variants/extensions/2.0/Vendor/FB_material_variants/README.md)
+/// Please see [the `KHR_materials_variants`
+/// spec](https://github.com/zellski/glTF/blob/ext/zell-fb-asset-variants/extensions/2.0/Khronos/KHR_materials_variants/README.md)
 /// for further details.
 pub fn get_validated_extension_tag(root: &Root, default_tag: Option<&Tag>) -> Result<Tag> {
     let extension_tag = get_tag_from_extension(root)?;
@@ -79,7 +79,7 @@ fn get_tag_from_extension(root: &Root) -> Result<Option<Tag>> {
 
 fn get_root_extension(root: &Root) -> Result<Option<FBMaterialVariantRootExtension>> {
     if let Some(extensions) = &root.extensions {
-        if let Some(ref boxed) = extensions.others.get(FB_MATERIAL_VARIANTS) {
+        if let Some(ref boxed) = extensions.others.get(KHR_MATERIALS_VARIANTS) {
             let json_string = boxed.to_string();
             let parse: serde_json::Result<FBMaterialVariantRootExtension> =
                 serde_json::from_str(&json_string);
@@ -89,12 +89,12 @@ fn get_root_extension(root: &Root) -> Result<Option<FBMaterialVariantRootExtensi
                         Ok(Some(parse))
                     } else {
                         Err(format!(
-                            "Missing default_tag in FB_material_variants root extension."
+                            "Missing default_tag in KHR_materials_variants root extension."
                         ))
                     }
                 }
                 Err(e) => Err(format!(
-                    "Bad JSON in FB_material_variants extension: {}; json = {}",
+                    "Bad JSON in KHR_materials_variants extension: {}; json = {}",
                     e.to_string(),
                     json_string,
                 )),

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -20,8 +20,8 @@
 //! perhaps digital content creation tools will include ways to export variational assets natively.
 //! Until that day, this is how we're doing it.
 //!
-//! In this prerelease version, the tool produces files with the vendor extension
-//! [`FB_material_variants`](https://github.com/zellski/glTF/blob/ext/zell-fb-asset-variants/extensions/2.0/Vendor/FB_material_variants/README.md).
+//! In this prerelease version, the tool produces files with the Khronos extension
+//! [`KHR_materials_variants`](https://github.com/zellski/glTF/blob/ext/zell-fb-asset-variants/extensions/2.0/Khronos/KHR_materials_variants/README.md).
 //! We are hopeful that the glTF community will find speedy consensus around a fully
 //! ratified extension, e.g. `KHR_material_variants`.
 //!
@@ -55,7 +55,7 @@ pub type Error = String;
 /// Convenience type for a Result using our Error.
 pub type Result<T> = ::std::result::Result<T, crate::Error>;
 
-/// The JSON/Serde implementation of `FB_material_variants`.
+/// The JSON/Serde implementation of `KHR_materials_variants`.
 pub mod extension;
 
 /// The VarationalAsset struct and associated functionality.

--- a/native/src/variational_asset/mod.rs
+++ b/native/src/variational_asset/mod.rs
@@ -20,7 +20,7 @@ pub mod wasm;
 /// The primary API data structure.
 ///
 /// The key property is a glTF asset in binary form (which will always implement
-/// the `FB_material_variants` extension), along with various useful metadata for
+/// the `KHR_materials_variants` extension), along with various useful metadata for
 /// the benefit of clients.
 ///
 /// The key method melds one variational asset into another:
@@ -52,7 +52,7 @@ pub mod wasm;
 #[wasm_bindgen]
 #[derive(Debug, Clone)]
 pub struct VariationalAsset {
-    /// The generated glTF for this asset. Will always implement `FB_material_variants`
+    /// The generated glTF for this asset. Will always implement `KHR_materials_variants`
     /// and is always in binary (GLB) form.
     pub(crate) glb: Vec<u8>,
 
@@ -75,10 +75,10 @@ pub struct AssetSizes {
 impl VariationalAsset {
     /// Generates a new `VariationalAsset` from a glTF file.
     ///
-    /// If the provided asset implements `FB_material_variants`, then `default_tag` must
+    /// If the provided asset implements `KHR_materials_variants`, then `default_tag` must
     /// either be empty or match the default tag within the asset.
     ///
-    /// If the asset doesn't implement `FB_material_variants`, then the argument
+    /// If the asset doesn't implement `KHR_materials_variants`, then the argument
     /// `default_tag` must be non-empty. If it does, then `default_tag` must either match
     /// what's in the asset, or else be empty.
     pub fn from_file(file: &Path, default_tag: Option<&Tag>) -> Result<VariationalAsset, Error> {
@@ -88,10 +88,10 @@ impl VariationalAsset {
 
     /// Generates a new `VariationalAsset` from a byte slice of glTF.
     ///
-    /// If the provided asset implements `FB_material_variants`, then `default_tag` must
+    /// If the provided asset implements `KHR_materials_variants`, then `default_tag` must
     /// either be empty or match the default tag within the asset.
     ///
-    /// If the asset doesn't implement `FB_material_variants`, then the argument
+    /// If the asset doesn't implement `KHR_materials_variants`, then the argument
     /// `default_tag` must be non-empty. If it does, then `default_tag` must either match
     /// what's in the asset, or else be empty.
     pub fn from_slice(
@@ -103,7 +103,7 @@ impl VariationalAsset {
         loaded.export()
     }
 
-    /// The generated glTF for this asset. Will always implement `FB_material_variants`
+    /// The generated glTF for this asset. Will always implement `KHR_materials_variants`
     /// and is always in binary (GLB) form.
     pub fn glb(&self) -> &[u8] {
         self.glb.as_slice()

--- a/native/src/work_asset/construct.rs
+++ b/native/src/work_asset/construct.rs
@@ -70,7 +70,7 @@ impl WorkAsset {
     /// the JSON. After this step, the asset is entirely self-contained, and the `file_base`
     /// argument is no longer used.
     ///
-    /// Next, we validate/retrieve any default tag embedded using the `FB_material_variants`
+    /// Next, we validate/retrieve any default tag embedded using the `KHR_materials_variants`
     /// extension. This tag must match the `default_tag` provided as argument, if any, and if none
     /// was provided it must exist in the asset. This ensure `WorkAsset.default_tag` always exists
     /// and makes sense.
@@ -87,7 +87,7 @@ impl WorkAsset {
     ///
     /// We require that `Primitive` fingerprints are unique, to within a tolerance.
     ///
-    /// Finally, each mesh and mesh primitive is inspected, and any `FB_material_variants` data is
+    /// Finally, each mesh and mesh primitive is inspected, and any `KHR_materials_variants` data is
     /// parsed and converted to a Tag->MeldKey mapping, filling in `mesh_primitive_variants` and
     /// completing the `WorkAsset` construction.
     pub fn new(

--- a/native/src/work_asset/export.rs
+++ b/native/src/work_asset/export.rs
@@ -20,10 +20,10 @@ impl<'a> WorkAsset {
     /// First, we put together the finished structured asset:
     /// - Clone the JSON in `WorkAsset.parse` as well as the `WorkAsset.blob` byte vector.
     /// - Write `WorkAsset.default_tag` into the root of the new JSON, using the
-    ///   `FB_material_variants` extension.
+    ///   `KHR_materials_variants` extension.
     /// - Iterate over every mesh and mesh primitive in `WorkAsset.mesh_primitive_variants`,
     ///   and wherever there is a non-empty variational Tag->Material mapping, convert that to
-    ///   `FB_material_variants` form and write it into the mesh primitive's JSON.
+    ///   `KHR_materials_variants` form and write it into the mesh primitive's JSON.
     ///
     /// Next, we count up all the metadata.
     ///


### PR DESCRIPTION
…(#23)

Now that we are aiming to ship the variant materials extension as a Khronos extension with a new name directly, modify usage in the repo and docs accordingly to export melded glTF files that reflect the new name -- see https://github.com/KhronosGroup/glTF/pull/1681

Test plan:
```
cargo test
./web/cli/dist/app.js matte:assets/pinecones_matte.glb shiny:assets/pinecones_shiny.glb assets/pinecones_variational.glb # confirm the resulting glTF JSON correctly exports and uses the correct extension name
```