### PR TITLE
Add support for revised schema

### DIFF
--- a/assets/pinecones/variational/Pinecone.gltf
+++ b/assets/pinecones/variational/Pinecone.gltf
@@ -3,6 +3,18 @@
     "generator": "FBX2glTF",
     "version": "2.0"
   },
+  "extensions": {
+    "KHR_materials_variants": {
+      "variants": [
+        {
+          "name": "tag_1"
+        },
+        {
+          "name": "tag_2"
+        }
+      ]
+    }
+  },
   "extensionsUsed": [
     "KHR_materials_variants"
   ],
@@ -131,9 +143,9 @@
             "KHR_materials_variants": {
               "mapping": [
                 {
-                  "tags": [
-                    "tag_1",
-                    "tag_2"
+                  "variants": [
+                    0,
+                    1
                   ],
                   "material": 0
                 }

--- a/native/src/extension/mod.rs
+++ b/native/src/extension/mod.rs
@@ -14,7 +14,7 @@ use gltf::json::Root;
 const KHR_MATERIALS_VARIANTS: &str = "KHR_materials_variants";
 
 mod on_root;
-pub use on_root::{get_validated_extension_tag, set_extension_tag};
+pub use on_root::{write_root_variant_lookup_map, get_variant_lookup};
 
 mod on_primitive;
 pub use on_primitive::{extract_variant_map, write_variant_map};

--- a/native/src/variational_asset/mod.rs
+++ b/native/src/variational_asset/mod.rs
@@ -134,8 +134,8 @@ impl VariationalAsset {
         base: &'a VariationalAsset,
         other: &'a VariationalAsset,
     ) -> Result<VariationalAsset, Error> {
-        let base = &WorkAsset::from_slice(base.glb(), None, None)?;
-        let other = &WorkAsset::from_slice(other.glb(), None, None)?;
+        let base = &WorkAsset::from_slice(base.glb(), Some(base.default_tag()), None)?;
+        let other = &WorkAsset::from_slice(other.glb(), Some(other.default_tag()), None)?;
 
         let meld = WorkAsset::meld(base, other)?;
         meld.export()

--- a/native/src/work_asset/mod.rs
+++ b/native/src/work_asset/mod.rs
@@ -68,6 +68,21 @@ impl WorkAsset {
         &self.blob.as_slice()
     }
 
+    /// Returns a vector of tags being used throughout the entire asset.
+    pub fn get_tags_in_use(&self) -> Result<Vec<Tag>> {
+        let mut tags_in_use: Vec<Tag> = Vec::new();
+        for vec_of_prims in &self.mesh_primitive_variants {
+            for tag_meld_entry in vec_of_prims {
+                for tag in tag_meld_entry.keys() {
+                    if !tags_in_use.contains(tag) {
+                        tags_in_use.push(tag.clone());
+                    }
+                }
+            }
+        };
+        Ok(tags_in_use)
+    }
+
     /// The mapping of `Tag` to material `MeldKey` for a given primitive of a given mesh.
     pub fn variant_mapping(&self, m_ix: usize, p_ix: usize) -> &HashMap<Tag, MeldKey> {
         let mesh_mappings = &self.mesh_primitive_variants[m_ix];

--- a/native/tests/variational_asset_tests.rs
+++ b/native/tests/variational_asset_tests.rs
@@ -4,6 +4,8 @@
 extern crate assets;
 extern crate gltf_variant_meld;
 
+use std::collections::{HashMap};
+
 use spectral::prelude::*;
 
 use gltf_variant_meld::{Tag, VariationalAsset, WorkAsset};
@@ -12,16 +14,20 @@ use assets::*;
 
 #[test]
 fn test_parse_simple_variational() {
-    let (tag_default, tag_1, tag_2) = (
-        Tag::from("tag_default"),
+    let (tag_1, tag_2) = (
         Tag::from("tag_1"),
         Tag::from("tag_2"),
     );
+
+    let mut variant_ix_lookup = HashMap::new();
+    variant_ix_lookup.insert(0, tag_1.to_owned());
+    variant_ix_lookup.insert(1, tag_2.to_owned());
+
     let asset_result =
-        VariationalAsset::from_file(ASSET_PINECONE_VARIATIONAL(), Some(&tag_default));
+        VariationalAsset::from_file(ASSET_PINECONE_VARIATIONAL(), Some(&tag_1));
     assert_that!(asset_result).is_ok();
     let asset = asset_result.unwrap();
-    let asset = WorkAsset::from_slice(asset.glb(), None, None)
+    let asset = WorkAsset::from_slice(asset.glb(), Some(&tag_2), None)
         .or_else(|e| Err(e.to_string()))
         .expect("glTF re-parse failure");
 
@@ -30,9 +36,9 @@ fn test_parse_simple_variational() {
         .primitives
         .get(0)
         .expect("No primitives in first mesh!");
-    let extracted_map = gltf_variant_meld::extension::extract_variant_map(&primitive)
+    let extracted_map = gltf_variant_meld::extension::extract_variant_map(&primitive, &variant_ix_lookup)
         .expect("Failed to extract variant map from mesh primitive.");
 
-    assert_that!(extracted_map).has_length(3);
-    assert_that!(extracted_map.keys()).contains_all_of(&vec![&tag_default, &tag_1, &tag_2]);
+    assert_that!(extracted_map).has_length(2);
+    assert_that!(extracted_map.keys()).contains_all_of(&vec![&tag_1, &tag_2]);
 }


### PR DESCRIPTION
Updating melding of assets to use the updated KHR_materials_variants schema that now includes:
* Adding root lookup dictionary for variants
* Index referenced variants instead of tags for mesh primitives